### PR TITLE
Add join and exit bindings

### DIFF
--- a/packages/bindings-test/src/error.rs
+++ b/packages/bindings-test/src/error.rs
@@ -8,4 +8,7 @@ pub enum ContractError {
 
     #[error("Invalid full denom '{full_denom}'")]
     InvalidFullDenom { full_denom: String },
+
+    #[error("Invalid number of assets added to pool")]
+    InvalidNumberOfAssets {},
 }

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -6,7 +6,8 @@ mod types;
 pub use msg::OsmosisMsg;
 pub use querier::OsmosisQuerier;
 pub use query::{
-    FullDenomResponse, OsmosisQuery, PoolStateResponse, SpotPriceResponse, SwapResponse,
+    FullDenomResponse, JoinPoolSharesResponse, OsmosisQuery, PoolStateResponse, SpotPriceResponse,
+    SwapResponse,
 };
 pub use types::{Step, Swap, SwapAmount, SwapAmountWithLimit};
 

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::SwapAmountWithLimit;
 use crate::{Step, Swap};
-use cosmwasm_std::{CosmosMsg, CustomMsg, Uint128};
+use cosmwasm_std::{Coin, CosmosMsg, CustomMsg, Uint128};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -45,6 +45,33 @@ pub enum OsmosisMsg {
         first: Swap,
         route: Vec<Step>,
         amount: SwapAmountWithLimit,
+    },
+    /// Add liquidity to a specified pool to get an exact amount of LP shares while specifying a maximum number tokens
+    /// willing to swap to receive said LP shares.
+    JoinPoolNoSwap {
+        pool_id: u64,
+        share_out_amount: Uint128,
+        token_in_maxs: Vec<Coin>,
+    },
+    /// Add liquidity to a specified pool with only one of the required assets (i.e. Join pool 1 (50/50 ATOM-OSMO) with just ATOM).
+    JoinSwapExactAmountIn {
+        pool_id: u64,
+        share_out_min_amount: Uint128,
+        token_in: Coin,
+    },
+    /// Remove liquidity from a specified pool with an **exact** amount of LP shares while specifying the **minimum** number of tokens willing to receive for said LP shares.
+    ExitPool {
+        pool_id: u64,
+        share_in_amount: Uint128,
+        token_out_mins: Vec<Coin>,
+    },
+    /// Remove an **exact** amount of LP shares from a specified pool, swap the LP shares to
+    /// one of the token pairs to receive a **minimum** of the specified token amount.
+    ExitSwapShareAmountIn {
+        pool_id: u64,
+        share_in_amount: Uint128,
+        token_out_min_amount: Uint128,
+        token_out_denom: String,
     },
 }
 

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -33,6 +33,8 @@ pub enum OsmosisQuery {
         route: Vec<Step>,
         amount: SwapAmount,
     },
+    /// Return the amount of shares and the liquidty given if a user joins a liquidity pool.
+    JoinPoolShares { pool_id: u64, coins: Vec<Coin> },
 }
 
 impl CustomQuery for OsmosisQuery {}
@@ -74,6 +76,14 @@ pub struct PoolStateResponse {
     pub assets: Vec<Coin>,
     /// The number of lp shares and their amount
     pub shares: Coin,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct JoinPoolSharesResponse {
+    /// The LP tokens a user would receive upon joining a liquidity pool.
+    pub assets: Vec<Coin>,
+    /// The number of lp shares and their amount
+    pub shares: Uint128,
 }
 
 impl PoolStateResponse {


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for joining and exiting a liquidity pool through CosmWasm contracts.

> Add a description of the overall background and high level changes that this PR introduces

This pull request adds support for joining and exiting liquidity pools symmetrically and asymmetrically.  Four different functions are implemented: `JoinPoolNoSwap`, `ExitPool`, `JoinSwapExternAmountIn` (renamed  `JoinSwapExactAmountIn`), and `ExitSwapExactAmountIn`. 

## Brief Changelog
 
- Adds JoinPool to the Wasm bindings
- Adds functions to Pool implementation
- Adds unit tests to check errors and logic

## Testing and Verifying

This change added tests and can be verified as follows:

  - Added unit test that validates the the correct amount of shares are minted when a user joins a liquidity pool
  - Added unit test that validates the the correct amount of shares are decreased when a user joins a liquidity pool
  
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - How is the feature or change documented? The changes provide a wrapper around the function: (x/gamm/keeper/pool_service/<function_name>)